### PR TITLE
Improved Type Safety with Generics

### DIFF
--- a/web/components/BaseItem.vue
+++ b/web/components/BaseItem.vue
@@ -1,8 +1,8 @@
-<script lang="ts" setup>
+<script lang="ts" setup generic="T extends Item">
 import { resolveDynamicComponent } from 'vue'
 import type { Item } from '#imports'
 
-const { item, isList } = defineProps<{ item: Item, isList: boolean }>()
+const { item, isList } = defineProps<{ item: T, isList: boolean }>()
 
 const itemComponent = resolveDynamicComponent('item-' + item.type)
 </script>

--- a/web/components/ItemDebt.vue
+++ b/web/components/ItemDebt.vue
@@ -1,11 +1,9 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T extends Item & { frontmatter: DebtFrontmatter }">
 import type { TableColumn } from '@nuxt/ui'
 import { type Item, type DebtFrontmatter, h, ref, computed, reactive } from '#imports'
 import { UButton } from '#components'
 
-const { item, isList } = defineProps<{ item: Item, isList?: boolean }>()
-
-const fm = item.frontmatter as DebtFrontmatter
+const { item, isList } = defineProps<{ item: T, isList?: boolean }>()
 
 type Transaction = {
   id: string
@@ -25,11 +23,11 @@ const progress = computed(() => {
 const formatCurrency = (amount: number) => {
   return new Intl.NumberFormat('ru-RU', {
     style: 'currency',
-    currency: fm.currency,
+    currency: item.frontmatter.currency,
   }).format(amount)
 }
 
-const transactions = ref<Transaction[]>(fm.transactions.map((tx) => {
+const transactions = ref<Transaction[]>(item.frontmatter.transactions.map((tx) => {
   if (tx.amount > 0) {
     total.value += tx.amount
   }
@@ -77,7 +75,7 @@ const columns: TableColumn<Transaction>[] = [
     cell: ({ row }) => {
       return new Intl.NumberFormat('ru-RU', {
         style: 'currency',
-        currency: fm.currency,
+        currency: item.frontmatter.currency,
       }).format(row.getValue('amount'))
     },
   },

--- a/web/components/ItemTrack.vue
+++ b/web/components/ItemTrack.vue
@@ -1,9 +1,7 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T extends Item & { frontmatter: TrackFrontmatter }">
 import type { Item, TrackFrontmatter } from '#imports'
 
-const { item } = defineProps<{ item: Item, isList?: boolean }>()
-
-const fm = item.frontmatter as TrackFrontmatter
+const { item } = defineProps<{ item: T, isList?: boolean }>()
 </script>
 
 <template>
@@ -11,10 +9,10 @@ const fm = item.frontmatter as TrackFrontmatter
     <p>
       <ULink
         as="button"
-        :to="fm.url"
+        :to="item.frontmatter.url"
         target="_blank"
         external
-      >{{ fm.url }}</ULink>
+      >{{ item.frontmatter.url }}</ULink>
     </p>
     <UButtonGroup class="mr-2">
       <UButton

--- a/web/utils/types.ts
+++ b/web/utils/types.ts
@@ -4,8 +4,12 @@ export type Item = {
   content: string
   completed: string
   type: ItemType
-  frontmatter: object
+  frontmatter: Frontmatter
 }
+
+export type Frontmatter =
+  | DebtFrontmatter
+  | TrackFrontmatter
 
 export type DebtTransaction = {
   amount: number


### PR DESCRIPTION
## This PR enhances the type safety of our item components by:
- Adding generic type parameters to `BaseItem.vue`, `ItemDebt.vue`, and `ItemTrack.vue`
- Replacing manual type assertions (`as DebtFrontmatter`) with proper type constraints
- Defining `Frontmatter` as a union type of specific frontmatter types
- Updating component props to properly infer and enforce types
- Removing redundant intermediate variables in favor of direct property access
---
These changes make our codebase more robust by catching potential type errors at compile time and improve developer experience with better IDE autocompletion.