### PR TITLE
feat(pb): refactor PocketBase usage to composable (closes #12)

### DIFF
--- a/web/components/AppNav.vue
+++ b/web/components/AppNav.vue
@@ -2,10 +2,11 @@
 import type { NavigationMenuItem } from '@nuxt/ui'
 import { navigateTo } from '#app'
 import {
-  pb,
   ref,
 } from '#imports'
+import { usePocketBase } from '~/utils/pb'
 
+const pb = usePocketBase()
 const onLogout = async () => {
   pb.authStore.clear()
   await navigateTo({ name: 'login' })

--- a/web/middleware/auth.ts
+++ b/web/middleware/auth.ts
@@ -1,7 +1,8 @@
 import { defineNuxtRouteMiddleware, navigateTo } from '#app'
-import { pb } from '#imports'
+import { usePocketBase } from '~/utils/pb'
 
 export default defineNuxtRouteMiddleware(() => {
+  const pb = usePocketBase()
   if (!pb.authStore.isValid) {
     return navigateTo({ name: 'login' })
   }

--- a/web/pages/login.vue
+++ b/web/pages/login.vue
@@ -1,12 +1,15 @@
 <script lang="ts" setup>
 import { onMounted, reactive } from 'vue'
 import { navigateTo } from '#app'
-import { useToast, pb } from '#imports'
+import { useToast } from '#imports'
+import { usePocketBase } from '~/utils/pb'
 
 const state = reactive({
   email: '',
   password: '',
 })
+
+const pb = usePocketBase()
 
 const isAuthorized = defineModel('isAuthorized', {
   type: Boolean,

--- a/web/stores/activities.ts
+++ b/web/stores/activities.ts
@@ -1,14 +1,16 @@
 import { defineStore } from 'pinia'
 import {
-  pb,
   type Item,
   type ItemType,
   shallowRef,
   transformItem,
   useFiltersStore,
 } from '#imports'
+import { usePocketBase } from '~/utils/pb'
 
 export const useActivitiesStore = defineStore('activities', () => {
+  const pb = usePocketBase()
+
   const items = shallowRef<Item[]>([])
   const itemTypes = shallowRef<Set<ItemType>>(new Set())
   const item = shallowRef<Item | undefined>(undefined)

--- a/web/utils/pb.ts
+++ b/web/utils/pb.ts
@@ -2,9 +2,9 @@ import PocketBase, { type RecordModel } from 'pocketbase'
 import { useRuntimeConfig } from '#app'
 import type { Item } from '#imports'
 
-const config = useRuntimeConfig()
-
-export const pb = new PocketBase(config.public.apiBase)
+export function usePocketBase() {
+  return new PocketBase(useRuntimeConfig().public.apiBase)
+}
 
 // TODO: fix type assertion with validation library
 export function transformItem(item: RecordModel): Item {

--- a/web/utils/services.ts
+++ b/web/utils/services.ts
@@ -1,10 +1,14 @@
-import { pb } from '#imports'
+import { usePocketBase } from '~/utils/pb'
+
+// TODO: should be in store???
 
 export function getItem(id: string) {
+  const pb = usePocketBase()
   return pb.collection('files').getOne(id)
 }
 
 export const toggleItem = async (id: string) => {
+  const pb = usePocketBase()
   const item = await getItem(id)
   if (item.frontmatter.completed) {
     item.frontmatter.completed = ''
@@ -19,6 +23,7 @@ export const toggleItem = async (id: string) => {
 }
 
 export const addDebtTransaction = async (id: string, amount: number, comment: string) => {
+  const pb = usePocketBase()
   const item = await getItem(id)
   const transaction = {
     amount: amount,


### PR DESCRIPTION
### Refactor PocketBase usage to composable

#### What’s changed
- Replaced all direct imports of `pb` with the new `usePocketBase()` composable.
- Updated all relevant files (`AppNav.vue`, `auth.ts`, `login.vue`, `activities.ts`, `services.ts`) to use `usePocketBase`.
- Refactored `web/utils/pb.ts` to export a factory function instead of a singleton.
- Ensured each usage gets a fresh PocketBase instance, improving modularity and testability.

#### Note on `services.ts`
- The current approach in `services.ts` (using `usePocketBase()` inside each function) is probably not optimal and may need to be refactored for better structure or moved to a store in the future.

#### Why
- Avoids global singleton state and potential side effects.
- Aligns with composable best practices in Nuxt 3.
- Makes it easier to mock or extend PocketBase usage in the future.

#### How to test
- Log in, log out, and perform actions that interact with PocketBase (e.g., fetching, toggling, or updating items).
- Ensure authentication and data operations work as expected.

---

Closes #12 
