### PR TITLE
fix(query): reset item id on component unmount

### DIFF
--- a/web/pages/items/[id].vue
+++ b/web/pages/items/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, shallowRef, ref, watch } from 'vue'
+import { onMounted, shallowRef, ref, watch, onUnmounted } from 'vue'
 import type { MDCParserResult } from '@nuxtjs/mdc'
 import {
   definePageMeta,
@@ -36,6 +36,9 @@ onMounted(async () => {
     return
   }
   id.value = route.params.id
+})
+onUnmounted(() => {
+  id.value = undefined
 })
 </script>
 


### PR DESCRIPTION
## Fix for Query Not Refreshing on Navigation

This PR addresses an issue where navigating between different item pages wasn't triggering a refetch of the query. By resetting the item ID on component unmount, we ensure the query will properly detect ID changes when navigating to a new item, forcing a refresh of the data.

Changes:
- Added `onUnmounted` lifecycle hook to reset query ID
- Imported the required hook from Vue

Fixes the issue where content wasn't updating when navigating between different item pages.
