### PR TITLE
Set query in buildQuery and fix initial loading of filters

### DIFF
--- a/web/composables/queries/useActivitiesQuery.ts
+++ b/web/composables/queries/useActivitiesQuery.ts
@@ -17,8 +17,11 @@ export const useActivitiesListQuery = defineQuery(() => {
   const size = ref(20)
 
   const { state } = useQuery<ListResult<ItemRecord>>({
-    key: () => ['activities', { filters: filtersStore.buildedQuery, page: page.value, size: size.value }],
-    query: async () => await client.getList(page.value, size.value, filtersStore.buildedQuery),
+    key: () => ['activities', { filters: filtersStore.builtQuery, page: page.value, size: size.value }],
+    query: async () => {
+      filtersStore.buildQuery()
+      return await client.getList(page.value, size.value, filtersStore.builtQuery)
+    },
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 10, // 10 minutes
   })

--- a/web/stores/filters.ts
+++ b/web/stores/filters.ts
@@ -10,7 +10,7 @@ export const useFiltersStore = defineStore('filters', () => {
   const pathFilterEnabled = useStorage('path-filter-enabled', false, localStorage)
   const typeFilterEnabled = useStorage('type-filter-enabled', false, localStorage)
 
-  const buildedQuery = ref('')
+  const builtQuery = ref('')
 
   function buildQuery() {
     const filterParts: string[] = []
@@ -28,7 +28,7 @@ export const useFiltersStore = defineStore('filters', () => {
         filterParts.push(query.value)
       }
     }
-    return filterParts.join(' && ')
+    builtQuery.value = filterParts.join(' && ')
   }
 
   watchDebounced(
@@ -40,7 +40,7 @@ export const useFiltersStore = defineStore('filters', () => {
       typeFilterEnabled,
     ],
     () => {
-      buildedQuery.value = buildQuery()
+      buildQuery()
     },
     { debounce: 300 },
   )
@@ -53,6 +53,6 @@ export const useFiltersStore = defineStore('filters', () => {
     pathFilterEnabled,
     typeFilterEnabled,
     buildQuery,
-    buildedQuery,
+    builtQuery,
   }
 })


### PR DESCRIPTION
Closes #30.

- Invoke buildQuery before querying activities
- Rename buildedQuery to builtQuery and invoke buildQuery in the query to ensure filters are built before fetching activities.