### PR TITLE
fix(components): standardize event handling for updateFrontmatter

### DIFF
--- a/web/components/ItemDebt.vue
+++ b/web/components/ItemDebt.vue
@@ -1,19 +1,9 @@
 <script lang="ts">
-import { z } from 'zod/v4-mini'
 import { computed } from 'vue'
 import { clamp } from '@vueuse/core'
 import type { ItemRecord, DebtFrontmatter } from '#pocketbase-imports'
 import type { BaseItemEmits } from './BaseItem.vue'
 
-export const formSchema = z.object({
-  date: z.optional(z.iso.datetime({ local: true })),
-  amount: z.number({ error: 'amount is required' }),
-  comment: z.optional(z.string().check(
-    z.maxLength(256, { error: 'comment is too long' }),
-  )),
-})
-
-export type FormState = z.infer<typeof formSchema>
 export type DebtData = {
   total: number
   returned: number
@@ -21,11 +11,11 @@ export type DebtData = {
   progress: number
 }
 
-export type DebtProps = { item: ItemRecord & { frontmatter: DebtFrontmatter }, compact?: boolean }
+export type DebtProps = { item: ItemRecord & { frontmatter: DebtFrontmatter }, compact?: boolean, loading?: boolean }
 </script>
 
 <script setup lang="ts">
-const { item, compact } = defineProps<DebtProps>()
+const { item, compact, loading } = defineProps<DebtProps>()
 
 const emits = defineEmits<BaseItemEmits>()
 
@@ -57,12 +47,13 @@ const debtData = computed<DebtData>(() => {
     v-if="compact"
     :item="item"
     :debt-data="debtData"
-    @toggle-completed="emits('updateFrontmatter', item)"
+    @update-frontmatter="(payload) => emits('updateFrontmatter', payload)"
   />
   <DebtDetailed
     v-else
     :item="item"
     :debt-data="debtData"
-    @toggle-completed="emits('updateFrontmatter', item)"
+    :loading="loading"
+    @update-frontmatter="(payload) => emits('updateFrontmatter', payload)"
   />
 </template>

--- a/web/components/ItemGroceries.vue
+++ b/web/components/ItemGroceries.vue
@@ -6,10 +6,6 @@ import type { BaseItemEmits } from './BaseItem.vue'
 const { item, compact, loading } = defineProps<{ item: ItemRecord & { frontmatter: GroceriesFrontmatter }, compact?: boolean, loading?: boolean }>()
 
 const emits = defineEmits<BaseItemEmits>()
-
-async function handleUpdateFrontmatter(payload: ItemRecord) {
-  emits('updateFrontmatter', payload)
-}
 </script>
 
 <template>
@@ -17,12 +13,12 @@ async function handleUpdateFrontmatter(payload: ItemRecord) {
     v-if="compact"
     :item="item"
     :loading="loading"
-    @update-frontmatter="handleUpdateFrontmatter"
+    @update-frontmatter="(payload) => emits('updateFrontmatter', payload)"
   />
   <GroceriesDetailed
     v-else
     :item="item"
     :loading="loading"
-    @update-frontmatter="handleUpdateFrontmatter"
+    @update-frontmatter="(payload) => emits('updateFrontmatter', payload)"
   />
 </template>

--- a/web/components/ItemNone.vue
+++ b/web/components/ItemNone.vue
@@ -18,7 +18,7 @@ const emits = defineEmits<BaseItemEmits>()
       color: 'warning',
     }"
     :loading="loading"
-    @toggle-completed="emits('updateFrontmatter', item)"
+    @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
     <div class="flex gap-2 items-center py-2">
       <p class="text-sm text-dimmed">

--- a/web/components/ItemTrack.vue
+++ b/web/components/ItemTrack.vue
@@ -1,29 +1,23 @@
 <script setup lang="ts" generic="T extends ItemRecord & { frontmatter: TrackFrontmatter }">
 import type { ItemRecord, TrackFrontmatter } from '#pocketbase-imports'
+import type { BaseItemEmits } from './BaseItem.vue'
 
-import { useActivitiesUpdateItemMutation } from '~/composables/queries'
+const { item, compact, loading } = defineProps<{ item: T, compact?: boolean, loading?: boolean }>()
 
-const { item, compact } = defineProps<{ item: T, compact?: boolean }>()
-const { mutateAsync, asyncStatus } = useActivitiesUpdateItemMutation()
-
-async function handleChange(payload: { key: string, n: number }) {
-  const newItem = { ...item }
-  newItem.frontmatter[payload.key] = payload.n
-  await mutateAsync(newItem)
-}
+const emits = defineEmits<BaseItemEmits>()
 </script>
 
 <template>
   <TrackCompact
     v-if="compact"
     :item="item"
-    :loading="asyncStatus === 'loading'"
-    @change="handleChange"
+    :loading="loading"
+    @update-frontmatter="(payload) => emits('updateFrontmatter', payload)"
   />
   <TrackDetailed
     v-else
     :item="item"
-    :loading="asyncStatus === 'loading'"
-    @change="handleChange"
+    :loading="loading"
+    @update-frontmatter="(payload) => emits('updateFrontmatter', payload)"
   />
 </template>

--- a/web/components/debt/AddEditForm.vue
+++ b/web/components/debt/AddEditForm.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { FormSubmitEvent } from '@nuxt/ui'
 import { onMounted, reactive } from '#imports'
-import { type FormState, formSchema } from '../ItemDebt.vue'
+import { type FormState, formSchema } from './Detailed.vue'
 
 const { defaults, type = 'add' } = defineProps<{
   defaults?: {

--- a/web/components/debt/Compact.vue
+++ b/web/components/debt/Compact.vue
@@ -17,7 +17,7 @@ const emits = defineEmits<BaseItemEmits>()
     :item="item"
     :icon="'i-lucide-credit-card'"
     :loading="loading"
-    @toggle-completed="emits('updateFrontmatter', item)"
+    @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
     <div class="pt-2">
       <UProgress

--- a/web/components/groceries/Compact.vue
+++ b/web/components/groceries/Compact.vue
@@ -24,7 +24,7 @@ const totalItems = computed(() => {
     :item="item"
     :icon="'i-lucide-shopping-cart'"
     :loading="loading"
-    @toggle-completed="emits('updateFrontmatter', item)"
+    @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
     <template #actions>
       <UBadge

--- a/web/components/groceries/Detailed.vue
+++ b/web/components/groceries/Detailed.vue
@@ -2,15 +2,14 @@
 import { computed, ref } from 'vue'
 import type { ItemRecord } from '#pocketbase-imports'
 import type { GroceriesFrontmatter } from '~/modules/pocketbase/types/schema'
+import type { BaseItemEmits } from '../BaseItem.vue'
 
 const { item, loading = false } = defineProps<{
   item: ItemRecord & { frontmatter: GroceriesFrontmatter }
   loading?: boolean
 }>()
 
-const emits = defineEmits<{
-  update: [payload: ItemRecord]
-}>()
+const emits = defineEmits<BaseItemEmits>()
 
 const newItem = ref('')
 
@@ -37,7 +36,7 @@ async function toggleItem(nameToToggle: string) {
         : item),
     },
   }
-  emits('update', payload)
+  emits('updateFrontmatter', payload)
 }
 
 async function addItem() {
@@ -49,7 +48,7 @@ async function addItem() {
       checklist: [...item.frontmatter.checklist, { name: newItem.value.trim(), done: false }],
     },
   }
-  emits('update', payload)
+  emits('updateFrontmatter', payload)
   newItem.value = ''
 }
 
@@ -61,7 +60,7 @@ async function removeItem(id: string) {
       checklist: item.frontmatter.checklist.filter(item => item.name !== id),
     },
   }
-  emits('update', payload)
+  emits('updateFrontmatter', payload)
 }
 </script>
 

--- a/web/components/track/Compact.vue
+++ b/web/components/track/Compact.vue
@@ -15,7 +15,7 @@ const emits = defineEmits<BaseItemEmits>()
     :item="item"
     :icon="'i-lucide-tv'"
     :loading="loading"
-    @toggle-completed="emits('updateFrontmatter', item)"
+    @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
     <template #actions>
       <UButton


### PR DESCRIPTION
Unify the event handler pattern across all item components by:
1. Adding loading prop to ItemDebt component
2. Moving form schema from ItemDebt to Detailed component
3. Standardizing event emission with payload parameter