### PR TITLE
refactor(components): rename ItemsListCard to ItemCard and improve co…

### DIFF
--- a/web/components/ItemCard.vue
+++ b/web/components/ItemCard.vue
@@ -7,9 +7,10 @@ export const iconColors = {
   danger: 'text-red-500',
 }
 
-export interface ItemsListCardProps {
+export interface ItemCardProps {
   item: ItemRecord
-  icon: string
+  icon?: string
+  compact?: boolean
   loading?: boolean
   disabled?: boolean
   iconColor?: keyof typeof iconColors
@@ -19,8 +20,9 @@ export interface ItemsListCardProps {
 <script lang="ts" setup>
 import { computed } from 'vue'
 import type { ItemRecord } from '#pocketbase-imports'
+import { toggleItem } from '#imports'
 
-const { item, iconColor = 'primary' } = defineProps<ItemsListCardProps>()
+const { item, iconColor = 'primary', icon = 'i-lucide-notebook-pen' } = defineProps<ItemCardProps>()
 
 const emits = defineEmits<{
   'toggle-completed': [item: ItemRecord]
@@ -35,21 +37,6 @@ const title = computed(() => item?.frontmatter?.title || item?.frontmatter?.summ
 const checked = computed(() => {
   return Boolean(item?.frontmatter?.completed)
 })
-
-function toggleItem(item: ItemRecord) {
-  const frontmatter = item.frontmatter || {}
-  if (frontmatter?.completed) {
-    frontmatter.completed = ''
-  }
-  else {
-    frontmatter.completed = new Date().toISOString().split('.')[0]!
-  }
-
-  return {
-    ...item,
-    frontmatter,
-  }
-}
 
 function handleToggleDone(item: ItemRecord) {
   emits('toggle-completed', toggleItem(item))
@@ -84,6 +71,8 @@ function handleToggleDone(item: ItemRecord) {
         </div>
       </div>
     </slot>
-    <slot />
+    <div class="py-4">
+      <slot />
+    </div>
   </UCard>
 </template>

--- a/web/components/ItemEmpty.vue
+++ b/web/components/ItemEmpty.vue
@@ -11,19 +11,20 @@ const emits = defineEmits<BaseItemEmits>()
 </script>
 
 <template>
-  <ItemsListCard
+  <ItemCard
     :item="item"
     :icon="'i-lucide-alert-circle'"
     :icon-variant="{
       color: 'warning',
     }"
+    compact
     :loading="loading"
     @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
-    <div class="flex gap-2 items-center py-2">
+    <div class="flex gap-2 items-center">
       <p class="text-sm text-dimmed">
         Empty item
       </p>
     </div>
-  </ItemsListCard>
+  </ItemCard>
 </template>

--- a/web/components/ItemNone.vue
+++ b/web/components/ItemNone.vue
@@ -11,19 +11,20 @@ const emits = defineEmits<BaseItemEmits>()
 </script>
 
 <template>
-  <ItemsListCard
+  <ItemCard
     :item="item"
     :icon="'i-lucide-alert-circle'"
     :icon-variant="{
       color: 'warning',
     }"
     :loading="loading"
+    compact
     @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
-    <div class="flex gap-2 items-center py-2">
+    <div class="flex gap-2 items-center">
       <p class="text-sm text-dimmed">
         This Item have data but no component
       </p>
     </div>
-  </ItemsListCard>
+  </ItemCard>
 </template>

--- a/web/components/debt/Compact.vue
+++ b/web/components/debt/Compact.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { BaseItemEmits } from '../BaseItem.vue'
 import type { DebtData, DebtProps } from '../ItemDebt.vue'
-import { ItemsListCard, UProgress } from '#components'
+import { ItemCard, UProgress } from '#components'
 
 const {
   item,
@@ -13,9 +13,10 @@ const emits = defineEmits<BaseItemEmits>()
 </script>
 
 <template>
-  <ItemsListCard
+  <ItemCard
     :item="item"
     :icon="'i-lucide-credit-card'"
+    compact
     :loading="loading"
     @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
@@ -24,5 +25,5 @@ const emits = defineEmits<BaseItemEmits>()
         :model-value="debtData.progress"
       />
     </div>
-  </ItemsListCard>
+  </ItemCard>
 </template>

--- a/web/components/debt/Detailed.vue
+++ b/web/components/debt/Detailed.vue
@@ -165,19 +165,12 @@ async function handleEdit(originalCreated: string, payload: FormState, expandCb:
 </script>
 
 <template>
-  <div>
-    <div
-      class="flex items-center mb-1"
-    >
-      <UIcon
-        name="i-lucide-credit-card"
-        class="mr-2 text-primary-500"
-      />
-      <h1 class="text-2xl font-bold">
-        {{ item.frontmatter.summary }}
-      </h1>
-    </div>
-
+  <ItemCard
+    :item="item"
+    :icon="'i-lucide-credit-card'"
+    :loading="loading"
+    @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
+  >
     <div>
       <h5>Всего: {{ formatCurrency(debtData.total) }}</h5>
       <h5>Возвращено: {{ formatCurrency(debtData.returned) }}</h5>
@@ -206,5 +199,5 @@ async function handleEdit(originalCreated: string, payload: FormState, expandCb:
         </template>
       </UTable>
     </div>
-  </div>
+  </ItemCard>
 </template>

--- a/web/components/groceries/Compact.vue
+++ b/web/components/groceries/Compact.vue
@@ -20,10 +20,11 @@ const totalItems = computed(() => {
 </script>
 
 <template>
-  <ItemsListCard
+  <ItemCard
     :item="item"
     :icon="'i-lucide-shopping-cart'"
     :loading="loading"
+    compact
     @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
     <template #actions>
@@ -53,5 +54,5 @@ const totalItems = computed(() => {
         Empty list
       </div>
     </div>
-  </ItemsListCard>
+  </ItemCard>
 </template>

--- a/web/components/groceries/Detailed.vue
+++ b/web/components/groceries/Detailed.vue
@@ -65,18 +65,13 @@ async function removeItem(id: string) {
 </script>
 
 <template>
-  <div class="flex flex-col gap-6">
+  <ItemCard
+    :item="item"
+    :icon="'i-lucide-shopping-cart'"
+    :loading="loading"
+    @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
+  >
     <div class="flex-1">
-      <div class="flex items-center mb-1">
-        <UIcon
-          name="i-lucide-shopping-cart"
-          class="mr-2 text-primary"
-        />
-        <h1 class="text-2xl font-bold">
-          {{ item.frontmatter.title }}
-        </h1>
-      </div>
-
       <div class="mb-4 flex flex-wrap items-center gap-2">
         <span
           v-if="formattedCreatedDate"
@@ -162,7 +157,7 @@ async function removeItem(id: string) {
     >
       List is empty. Add your first item!
     </div>
-  </div>
+  </ItemCard>
 </template>
 
 <style scoped>

--- a/web/components/track/Compact.vue
+++ b/web/components/track/Compact.vue
@@ -11,10 +11,11 @@ const emits = defineEmits<BaseItemEmits>()
 </script>
 
 <template>
-  <ItemsListCard
+  <ItemCard
     :item="item"
     :icon="'i-lucide-tv'"
     :loading="loading"
+    compact
     @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
   >
     <template #actions>
@@ -49,5 +50,5 @@ const emits = defineEmits<BaseItemEmits>()
         />
       </div>
     </div>
-  </ItemsListCard>
+  </ItemCard>
 </template>

--- a/web/components/track/Detailed.vue
+++ b/web/components/track/Detailed.vue
@@ -27,38 +27,14 @@ const formattedCreatedDate = computed(() => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-6">
+  <ItemCard
+    :item="item"
+    class="ring-0"
+    icon="i-lucide-tv-2"
+    @toggle-completed="(payload) => emits('updateFrontmatter', payload)"
+  >
     <div class="flex-1">
-      <div class="flex items-center mb-1">
-        <UIcon
-          name="i-lucide-tv-2"
-          class="mr-2 text-primary-500"
-        />
-        <h1 class="text-2xl font-bold">
-          {{ item.frontmatter.summary }}
-        </h1>
-      </div>
-
       <div class="mb-4 flex flex-wrap items-center gap-2">
-        <UBadge
-          v-if="item.frontmatter.rating"
-          color="warning"
-        >
-          {{ item.frontmatter.rating }}
-        </UBadge>
-        <UBadge
-          v-if="!item.frontmatter.completed"
-          color="primary"
-        >
-          Ongoing
-        </UBadge>
-        <UBadge
-          v-else
-          color="success"
-        >
-          Completed
-        </UBadge>
-
         <span
           v-if="formattedCreatedDate"
           class="text-xs"
@@ -161,5 +137,5 @@ const formattedCreatedDate = computed(() => {
         </div>
       </div>
     </div>
-  </div>
+  </ItemCard>
 </template>

--- a/web/utils/itemsHelper.ts
+++ b/web/utils/itemsHelper.ts
@@ -1,0 +1,16 @@
+import type { ItemRecord } from '#pocketbase-imports'
+
+export function toggleItem(item: ItemRecord) {
+  const frontmatter = item.frontmatter || {}
+  if (frontmatter?.completed) {
+    frontmatter.completed = ''
+  }
+  else {
+    frontmatter.completed = new Date().toISOString().split('.')[0]!
+  }
+
+  return {
+    ...item,
+    frontmatter,
+  }
+}


### PR DESCRIPTION
This refactor improves component organization by:
- Renaming ItemsListCard.vue to ItemCard.vue for better naming clarity
- Extracting toggleItem function to utils/itemsHelper.ts for reusability
- Adding compact prop to ItemCard for flexible layouts
- Standardizing component structure across different item types
- Improving slot handling with proper padding in ItemCard

BREAKING CHANGE: ItemsListCard is now ItemCard with a slightly different API



