### PR TITLE
feat(filters): add copy filter functionality to QueryFilterForm and filters store

### DIFF
--- a/web/components/QueryFilterForm.vue
+++ b/web/components/QueryFilterForm.vue
@@ -64,25 +64,23 @@ function handleDeleteFilter() {
         class="w-full"
       />
       <UButton
-        label="Copy"
         variant="soft"
         icon="i-lucide-copy"
+        size="lg"
         :disabled="!filtersStore.appliedFilterId"
         @click="filtersStore.copyFilter()"
-      >
-        Copy
-      </UButton>
+      />
       <UButton
-        label="Save"
         variant="soft"
         icon="i-lucide-save"
+        size="lg"
         :disabled="!filtersStore.saveFilterLabel"
         @click="filtersStore.saveFilter()"
       />
       <UButton
-        label="Delete"
         variant="soft"
         color="error"
+        size="lg"
         :disabled="!filtersStore.appliedFilterId"
         icon="i-lucide-trash"
         @click="deleteModal = true"

--- a/web/components/QueryFilterForm.vue
+++ b/web/components/QueryFilterForm.vue
@@ -64,6 +64,15 @@ function handleDeleteFilter() {
         class="w-full"
       />
       <UButton
+        label="Copy"
+        variant="soft"
+        icon="i-lucide-copy"
+        :disabled="!filtersStore.appliedFilterId"
+        @click="filtersStore.copyFilter()"
+      >
+        Copy
+      </UButton>
+      <UButton
         label="Save"
         variant="soft"
         icon="i-lucide-save"

--- a/web/stores/filters.ts
+++ b/web/stores/filters.ts
@@ -88,6 +88,36 @@ export const useFiltersStore = defineStore('filters', () => {
     return filter
   }
 
+  function copyFilter() {
+    if (!appliedFilterId.value) {
+      return false
+    }
+
+    const currentFilter = localFilters.value.find(f => f.id === appliedFilterId.value)
+    if (!currentFilter) {
+      return false
+    }
+
+    const id = crypto.randomUUID()
+    const copiedFilter: Filter = {
+      id,
+      label: `${currentFilter.label} (Copy)`,
+      query: query.value,
+      queryType: queryType.value,
+      pathFilter: pathFilter.value,
+      typeFilter: typeFilter.value,
+      pathFilterEnabled: pathFilterEnabled.value,
+      typeFilterEnabled: typeFilterEnabled.value,
+    }
+
+    localFilters.value.push(copiedFilter)
+
+    appliedFilterId.value = id
+    saveFilterLabel.value = copiedFilter.label
+
+    return copiedFilter
+  }
+
   function clearForm() {
     saveFilterLabel.value = ''
   }
@@ -156,6 +186,7 @@ export const useFiltersStore = defineStore('filters', () => {
     // functions
     buildQuery,
     saveFilter,
+    copyFilter,
     applyFilter,
     clearFilters,
     deleteFilter,


### PR DESCRIPTION
- Introduced a "Copy" button in QueryFilterForm to duplicate applied filters.
- Implemented copyFilter method in filters store to handle filter duplication logic, including generating a new ID and updating the applied filter state.