### PR TITLE
Fix adding new filter on non-TLS, close form on save

### DIFF
--- a/example/notes/unknown_type.md
+++ b/example/notes/unknown_type.md
@@ -1,0 +1,13 @@
+---
+aliases:
+title: Unknown Type
+status: Test
+type: unknown
+comment: ""
+tags:
+  - content
+created: 2024-10-18T18:05:07
+modified: 2025-05-06T16:04:26
+---
+
+# Unknown

--- a/web/modules/pocketbase/runtime/utils/mock.ts
+++ b/web/modules/pocketbase/runtime/utils/mock.ts
@@ -7,10 +7,11 @@ import debts from '~/assets/mock/debts.json'
 import tracks from '~/assets/mock/tracks.json'
 import withContent from '~/assets/mock/withContent.json'
 import PocketBase from 'pocketbase'
+import { nanoid } from 'nanoid'
 
 const createDefaultReturn = () => {
   const defaultReturn: RecordModel = {
-    id: crypto.randomUUID().toString(),
+    id: nanoid(),
     collectionId: 'pbc_boba',
     collectionName: 'files',
     path: '',

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "@vueuse/integrations": "^13.3.0",
     "@vueuse/nuxt": "13.1.0",
     "defu": "^6.1.4",
+    "nanoid": "^5.1.5",
     "nuxt": "^3.17.2",
     "pinia": "^3.0.2",
     "pocketbase": "^0.26.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.4
+      nanoid:
+        specifier: ^5.1.5
+        version: 5.1.5
       nuxt:
         specifier: ^3.17.2
         version: 3.17.2(@parcel/watcher@2.5.1)(@types/node@22.15.5)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.26.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.5)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.7.1)

--- a/web/stores/filters.ts
+++ b/web/stores/filters.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { useLocalStorage, useStorage, watchDebounced } from '@vueuse/core'
 import { ref } from 'vue'
 import { useNotebaseConfig } from '#imports'
+import { nanoid } from 'nanoid'
 
 interface Filter {
   id: string
@@ -61,7 +62,7 @@ export const useFiltersStore = defineStore('filters', () => {
   }
 
   function saveFilter() {
-    const id = crypto.randomUUID()
+    const id = nanoid()
     if (!saveFilterLabel.value) {
       return
     }
@@ -85,6 +86,7 @@ export const useFiltersStore = defineStore('filters', () => {
       localFilters.value.push(filter)
       clearForm()
     }
+    notebaseConfig.setShowFilters(false)
     return filter
   }
 
@@ -98,7 +100,7 @@ export const useFiltersStore = defineStore('filters', () => {
       return false
     }
 
-    const id = crypto.randomUUID()
+    const id = nanoid()
     const copiedFilter: Filter = {
       id,
       label: `${currentFilter.label} (Copy)`,


### PR DESCRIPTION
- crypto doesn't work on http, only on https, and it complicates local development
- we can close the filter form right after saving to save clicks/taps
- new example file with an unknown type to test out how out renders