### PR TITLE
Properly handle unknown types

### DIFF
--- a/web/components/BaseItem.vue
+++ b/web/components/BaseItem.vue
@@ -17,11 +17,7 @@ import type { ItemRecord } from '#pocketbase-imports'
 import { useActivitiesUpdateItemMutation } from '~/composables/queries'
 import { itemTypes } from '~/modules/pocketbase/types/schema'
 
-const props = withDefaults(defineProps<BaseItemProps>(), {
-  compact: false,
-  loading: false,
-  disabled: false,
-})
+const props = defineProps<BaseItemProps>()
 
 const itemType = computed(() => {
   if (Object.keys(itemTypes).includes(props.item?.frontmatter?.type ?? 'none')) {

--- a/web/components/BaseItem.vue
+++ b/web/components/BaseItem.vue
@@ -15,6 +15,7 @@ export interface BaseItemProps {
 import { computed, resolveDynamicComponent } from 'vue'
 import type { ItemRecord } from '#pocketbase-imports'
 import { useActivitiesUpdateItemMutation } from '~/composables/queries'
+import { itemTypes } from '~/modules/pocketbase/types/schema'
 
 const props = withDefaults(defineProps<BaseItemProps>(), {
   compact: false,
@@ -23,7 +24,10 @@ const props = withDefaults(defineProps<BaseItemProps>(), {
 })
 
 const itemType = computed(() => {
-  return props.item?.frontmatter?.type ?? 'none'
+  if (Object.keys(itemTypes).includes(props.item?.frontmatter?.type ?? 'none')) {
+    return props.item?.frontmatter?.type
+  }
+  return itemTypes.none
 })
 
 const itemComponent = computed(() => {


### PR DESCRIPTION
If the type of the item is not known, then the card is not rendered properly. We have 'none' type for these cases, so we just need to make sure that unknown types get 'none' component