### PR TITLE
refactor(layout): improve sticky header structure and backdrop

### DIFF
--- a/web/components/AppFilters.vue
+++ b/web/components/AppFilters.vue
@@ -13,7 +13,7 @@ defineShortcuts({
 </script>
 
 <template>
-  <div class="flex py-4 sticky top-0 z-10 bg-(--ui-bg)">
+  <div>
     <UButtonGroup class="w-full">
       <AppDrawer />
       <UInput

--- a/web/layouts/default.vue
+++ b/web/layouts/default.vue
@@ -2,9 +2,13 @@
 </script>
 
 <template>
-  <UContainer class="flex flex-col relative overflow-x-hidden">
-    <AppFilters />
-    <AppSettings />
-    <slot />
-  </UContainer>
+  <div class="flex flex-col h-dvh w-dvw relative overflow-x-hidden">
+    <UContainer class="flex py-4 backdrop-blur-xs min-h-[72px] flex-col sticky top-0 z-10">
+      <AppFilters />
+      <AppSettings />
+    </UContainer>
+    <UContainer>
+      <slot />
+    </UContainer>
+  </div>
 </template>


### PR DESCRIPTION
- Move sticky positioning from AppFilters to default layout
- Add backdrop-blur-xs effect to header container
- Restructure layout with proper full viewport dimensions
- Separate content containers for better visual hierarchy
- Remove redundant styling from AppFilters component